### PR TITLE
feat: Implement core API key management features and fix build issues

### DIFF
--- a/kees/kees/APIKeyEntryView.swift
+++ b/kees/kees/APIKeyEntryView.swift
@@ -12,11 +12,13 @@ struct APIKeyEntryView: View {
     // State for expiration date
     @State private var hasExpirationDate: Bool = false
     @State private var expirationDateInput: Date = Date() // Default to today, shown if hasExpirationDate is true
+    @State private var isFavoriteState: Bool = false // State for favorite toggle
 
     // Optional property for an existing key being edited (nil for new keys)
-    var apiKeyToEdit: APIKey? // Using the non-CoreData APIKey struct for now
+    var apiKeyToEdit: StoredAPIKey? // Changed to StoredAPIKey
 
-    // Environment variable to dismiss the view (e.g., when presented as a sheet)
+    // Environment variables
+    @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.dismiss) var dismiss
 
     var body: some View {
@@ -38,18 +40,25 @@ struct APIKeyEntryView: View {
                     if hasExpirationDate {
                         DatePicker("Expiration Date", selection: $expirationDateInput, in: Date()..., displayedComponents: .date)
                     }
+                    Toggle("Favorite", isOn: $isFavoriteState) // Added Favorite toggle
                 }
             }
             .navigationTitle(apiKeyToEdit == nil ? "Add API Key" : "Edit API Key")
             .onAppear {
-                // If editing an existing key, pre-fill the form fields
                 if let key = apiKeyToEdit {
-                    name = key.name
-                    keyValue = key.keyValue
-                    creationDate = key.creationDate
+                    name = key.name ?? ""
+                    keyValue = key.keyValue ?? ""
+                    creationDate = key.creationDate ?? Date() // Use actual creation date
                     descriptionText = key.descriptionText ?? ""
                     usageLocation = key.usageLocation ?? ""
-                    tagsInput = (key.tags ?? []).joined(separator: ", ")
+                    isFavoriteState = key.isFavorite // Set favorite state
+                    // Convert NSArray (from Core Data) to [String] then to comma-separated String
+                    if let tagsArray = key.tags as? [String] {
+                        tagsInput = tagsArray.joined(separator: ", ")
+                    } else {
+                        tagsInput = ""
+                    }
+                    
                     if let expDate = key.expirationDate {
                         hasExpirationDate = true
                         expirationDateInput = expDate
@@ -59,49 +68,100 @@ struct APIKeyEntryView: View {
                 }
             }
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {
                         dismiss()
                     }
                 }
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
-                        // Save action to be implemented later
-                        print("Save button tapped")
-                        print("Name: \(name), Key: \(keyValue), Date: \(creationDate)")
-                        print("Description: \(descriptionText), Location: \(usageLocation), Tags: \(tagsInput)")
-                        if hasExpirationDate {
-                            print("Expiration Date: \(expirationDateInput)")
-                        } else {
-                            print("No Expiration Date")
-                        }
-                        // dismiss()
+                        saveKey()
                     }
                 }
             }
         }
     }
-}
 
-struct APIKeyEntryView_Previews: PreviewProvider {
-    static var previews: some View {
-        // Preview for adding a new key
-        APIKeyEntryView()
-            .previewDisplayName("Add New Key")
+    private func saveKey() {
+        let keyToSave: StoredAPIKey
+        if let existingKey = apiKeyToEdit {
+            keyToSave = existingKey
+        } else {
+            keyToSave = StoredAPIKey(context: viewContext)
+            keyToSave.id = UUID() // Set ID for new keys
+            // creationDate is already managed by @State, will be assigned below
+        }
 
-        // Preview for editing an existing key with expiration
-        APIKeyEntryView(apiKeyToEdit: APIKey(name: "Test Key with Expiry", 
-                                             keyValue: "12345abcdef", 
-                                             descriptionText: "A test API key.", 
-                                             usageLocation: "Test Project", 
-                                             tags: ["test", "example"],
-                                             expirationDate: Calendar.current.date(byAdding: .month, value: 1, to: Date())))
-            .previewDisplayName("Edit Key with Expiry")
+        keyToSave.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        keyToSave.keyValue = keyValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        keyToSave.creationDate = creationDate // Ensure this @State var is used
+        keyToSave.descriptionText = descriptionText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : descriptionText.trimmingCharacters(in: .whitespacesAndNewlines)
+        keyToSave.usageLocation = usageLocation.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : usageLocation.trimmingCharacters(in: .whitespacesAndNewlines)
         
-        // Preview for editing an existing key without expiration
-        APIKeyEntryView(apiKeyToEdit: APIKey(name: "Test Key No Expiry",
-                                             keyValue: "67890uvwxyz",
-                                             descriptionText: "Another test key."))
-            .previewDisplayName("Edit Key No Expiry")
+        let processedTags = tagsInput.split(separator: ",")
+                                     .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                                     .filter { !$0.isEmpty }
+        keyToSave.tags = processedTags.isEmpty ? nil : (processedTags as NSArray)
+
+        if hasExpirationDate {
+            keyToSave.expirationDate = expirationDateInput
+        } else {
+            keyToSave.expirationDate = nil
+        }
+        
+        keyToSave.isFavorite = isFavoriteState // Save favorite state
+
+        do {
+            try viewContext.save()
+            dismiss()
+        } catch {
+            // Handle the Core Data save error (e.g., show an alert to the user)
+            print("Failed to save API key: \(error.localizedDescription)")
+            // Optionally, present an alert to the user here
+        }
     }
 }
+
+#if DEBUG
+struct APIKeyEntryView_Previews: PreviewProvider {
+    static var previews: some View {
+        let previewContext = CoreDataStack.preview.container.viewContext
+
+        // Sample StoredAPIKey for editing preview (Favorite)
+        let sampleKeyToEditFav = StoredAPIKey(context: previewContext)
+        sampleKeyToEditFav.id = UUID()
+        sampleKeyToEditFav.name = "Test Key to Edit (Favorite)"
+        sampleKeyToEditFav.keyValue = "editThisKeyFav123"
+        sampleKeyToEditFav.creationDate = Date()
+        sampleKeyToEditFav.tags = ["editing", "sample", "fav"] as NSArray
+        sampleKeyToEditFav.expirationDate = Calendar.current.date(byAdding: .day, value: 30, to: Date())
+        sampleKeyToEditFav.isFavorite = true
+        
+        // Sample StoredAPIKey for editing preview (Not Favorite)
+        let sampleKeyToEditNotFav = StoredAPIKey(context: previewContext)
+        sampleKeyToEditNotFav.id = UUID()
+        sampleKeyToEditNotFav.name = "Test Key to Edit (Not Fav)"
+        sampleKeyToEditNotFav.keyValue = "editThisKeyNotFav456"
+        sampleKeyToEditNotFav.creationDate = Date()
+        sampleKeyToEditNotFav.isFavorite = false
+
+
+        return Group {
+            // Preview for adding a new key
+            APIKeyEntryView()
+                .environment(\.managedObjectContext, previewContext)
+                .previewDisplayName("Add New Key")
+
+            // Preview for editing an existing favorite key
+            APIKeyEntryView(apiKeyToEdit: sampleKeyToEditFav)
+                .environment(\.managedObjectContext, previewContext)
+                .previewDisplayName("Edit Favorite Key")
+                
+            // Preview for editing an existing non-favorite key
+            APIKeyEntryView(apiKeyToEdit: sampleKeyToEditNotFav)
+                .environment(\.managedObjectContext, previewContext)
+                .previewDisplayName("Edit Non-Favorite Key")
+        }
+    }
+}
+#endif

--- a/kees/kees/ContentView.swift
+++ b/kees/kees/ContentView.swift
@@ -10,20 +10,58 @@ struct ContentView: View {
     // Access the AppStorage variable for theme preference
     @AppStorage("appTheme") var appTheme: AppTheme = .system
 
+    // Enum for filter types
+    enum FilterType: String, CaseIterable, Identifiable {
+        case all = "All Keys"
+        case favorites = "Favorites"
+        case recentlyUsed = "Recently Used" // Corrected: "Recently Used" as per sidebar labels
+        var id: String { self.rawValue }
+    }
+    @State private var currentFilter: FilterType = .all // State for current filter
+
+    // FetchRequest to get all StoredAPIKey entities, sorted by creationDate descending
+    // This remains the primary source of truth from Core Data.
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \StoredAPIKey.creationDate, ascending: false)],
+        animation: .default)
+    private var apiKeys: FetchedResults<StoredAPIKey>
+
+    // Computed property to filter keys based on the currentFilter state
+    private var filteredApiKeys: [StoredAPIKey] {
+        switch currentFilter {
+        case .all:
+            return Array(apiKeys)
+        case .favorites:
+            return apiKeys.filter { $0.isFavorite }
+        case .recentlyUsed:
+            // For now, "Recently Used" shows all keys sorted by creation date.
+            // Future enhancement could be to filter by a 'lastAccessedDate' or limit to top N.
+            return Array(apiKeys)
+        }
+    }
+
     var body: some View {
         NavigationSplitView {
             // Sidebar
             List(selection: $selectedCategory) {
-                Section("General") {
-                    Label("All Keys", systemImage: "list.bullet")
-                        .tag("All Keys")
-                    Label("Recently Used", systemImage: "clock.arrow.circlepath")
-                        .tag("Recently Used")
-                    Label("Favorites", systemImage: "heart.fill")
-                        .tag("Favorites")
-                }
+                // Section("General") { // These are now effectively handled by the Picker
+                //     Label("All Keys", systemImage: "list.bullet")
+                //         .tag("All Keys")
+                //     Label("Recently Used", systemImage: "clock.arrow.circlepath")
+                //         .tag("Recently Used")
+                //     Label("Favorites", systemImage: "heart.fill")
+                //         .tag("Favorites")
+                // }
                 
-                Section("Filters") {
+                Section("Filter Keys") { // Changed section title
+                    Picker("Filter", selection: $currentFilter) {
+                        ForEach(FilterType.allCases) { filterValue in
+                            Text(filterValue.rawValue).tag(filterValue) // Use rawValue for display
+                        }
+                    }
+                    .pickerStyle(.inline) // Or .menu for a dropdown style in sidebar
+                    
+                    // Placeholder for tag filters can go here later
                      Text("Tag Filters Placeholder")
                         .font(.caption)
                         .foregroundColor(.gray)
@@ -40,21 +78,39 @@ struct ContentView: View {
             .navigationTitle("Kees")
             .listStyle(SidebarListStyle())
         } detail: {
-            // Main Content Panel
-            VStack {
-                if let category = selectedCategory {
-                    Text("Displaying: \(category)")
+            // Main Content Panel - Displaying the list of API Keys
+            // For now, this always shows all keys. Filtering based on selectedCategory can be added later.
+            if filteredApiKeys.isEmpty {
+                VStack {
+                    // Dynamic empty state message based on current filter
+                    let emptyMessage = "No API keys found"
+                    let filterSpecificMessage: String
+                    switch currentFilter {
+                    case .all:
+                        filterSpecificMessage = emptyMessage + "."
+                    case .favorites:
+                        filterSpecificMessage = "No favorite API keys found."
+                    case .recentlyUsed:
+                        filterSpecificMessage = "No recently used API keys found (or feature not fully implemented)."
+                    }
+                    Text(filterSpecificMessage)
                         .font(.title)
-                } else {
-                    Text("Select a category or filter to see API Keys")
-                        .font(.title)
+                    Text("Add one using the '+' button or Cmd+N.")
+                        .font(.headline)
                         .foregroundColor(.secondary)
-                    // Placeholder for API Key list/grid will go here
                 }
+            } else {
+                List {
+                    ForEach(filteredApiKeys) { apiKey in
+                        APIKeyRowView(apiKey: apiKey)
+                    }
+                    .onDelete(perform: deleteAPIKeys) // Enable swipe-to-delete
+                }
+                // .listStyle(.plain) // Optional: for a different list appearance
             }
-            .navigationTitle(selectedCategory ?? "Overview")
+            .navigationTitle(currentFilter.rawValue) // Dynamic title based on current filter
             .toolbar {
-                ToolbarItem(placement: .primaryAction) { // Primary action for macOS often on the right
+                ToolbarItem(placement: .primaryAction) {
                     Button {
                         uiState.showingAddKeySheet = true
                     } label: {
@@ -70,12 +126,39 @@ struct ContentView: View {
                 // Pass other environment objects if APIKeyEntryView needs them, e.g., uiState
                 // .environmentObject(uiState) // Only if APIKeyEntryView needs to dismiss itself or modify shared state
         }
+        .onAppear {
+            // Schedule notifications when the ContentView appears.
+            // This will be called each time the view appears, which might be too frequent for some scenarios,
+            // but for this basic implementation, it ensures notifications are re-evaluated.
+            // A more advanced implementation might limit this to once per app launch or use background tasks.
+            NotificationManager.shared.scheduleExpirationNotifications(using: viewContext, daysBefore: 7)
+        }
+    }
+
+    private func deleteAPIKeys(offsets: IndexSet) {
+        withAnimation { // Animates the row deletion
+            // Important: The offsets are for 'filteredApiKeys'.
+            // We need to delete the actual objects from the viewContext.
+            let keysToDelete = offsets.map { filteredApiKeys[$0] }
+            keysToDelete.forEach(viewContext.delete)
+
+            do {
+                try viewContext.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // In a shipping application, you might want to present an error message to the user.
+                let nsError = error as NSError
+                print("Unresolved error deleting API key(s): \(nsError), \(nsError.userInfo)")
+                // For example, you could set a state variable to show an alert.
+                // self.showingDeleteErrorAlert = true
+            }
+        }
     }
 }
 
 #Preview {
     // Preview with the Core Data context and UIState
     ContentView()
-        .environment(\.managedObjectContext, CoreDataStack.shared.persistentContainer.viewContext)
+        .environment(\.managedObjectContext, CoreDataStack.preview.container.viewContext) // Use preview context
         .environmentObject(UIState()) // Provide a dummy UIState for preview
 }

--- a/kees/kees/CoreDataStack.swift
+++ b/kees/kees/CoreDataStack.swift
@@ -47,4 +47,38 @@ class CoreDataStack {
     //         return []
     //     }
     // }
+
+    // MARK: - Preview Specific Stack
+    #if DEBUG
+    static var preview: CoreDataStack = {
+        let result = CoreDataStack(inMemory: true)
+        let viewContext = result.persistentContainer.viewContext
+        // Optional: Add sample data for previews here if desired
+        // For example, create a few StoredAPIKey instances for global preview use.
+        // let key1 = StoredAPIKey(context: viewContext)
+        // key1.id = UUID()
+        // key1.name = "Preview Key 1"
+        // key1.keyValue = "preview123"
+        // key1.creationDate = Date()
+        // do {
+        //     try viewContext.save()
+        // } catch {
+        //     let nsError = error as NSError
+        //     fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+        // }
+        return result
+    }()
+
+    init(inMemory: Bool = false) {
+        persistentContainer = NSPersistentContainer(name: modelName)
+        if inMemory {
+            persistentContainer.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
+        }
+        persistentContainer.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+    }
+    #endif
 }

--- a/kees/kees/KeesDataModel.xcdatamodeld/contents
+++ b/kees/kees/KeesDataModel.xcdatamodeld/contents
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model name="KeesDataModel" userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22700" systemVersion="23E214" minimumToolsVersion="Xcode 4.3" macOSVersion="14.4" iOSVersion="17.4">
-    <entity name="StoredAPIKey" representedClassName="StoredAPIKey" syncable="YES">
+<model name="KeesDataModel" currentVersion="KeesDataModel" userDefinedModelVersionIdentifier="KeesDataModel" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22700" systemVersion="23E214" minimumToolsVersion="Xcode 4.3" macOSVersion="14.4" iOSVersion="17.4">
+    <entity name="StoredAPIKey" representedClassName="StoredAPIKey" codegenName="StoredAPIKey" codeGenerationStrategy="class" syncable="YES">
         <attribute name="creationDate" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="descriptionText" attributeType="String" usesScalarValueType="NO" optional="YES" syncable="YES"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO" syncable="YES"/>
@@ -9,5 +9,6 @@
         <attribute name="tags" attributeType="Transformable" usesScalarValueType="NO" optional="YES" customClassName="NSArray" transformerName="NSSecureUnarchiveFromDataTransformer" syncable="YES"/>
         <attribute name="usageLocation" attributeType="String" usesScalarValueType="NO" optional="YES" syncable="YES"/>
         <attribute name="expirationDate" attributeType="Date" usesScalarValueType="NO" optional="YES" syncable="YES"/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
     </entity>
 </model>

--- a/kees/kees/NotificationManager.swift
+++ b/kees/kees/NotificationManager.swift
@@ -1,0 +1,93 @@
+import UserNotifications
+import CoreData // For NSManagedObjectContext and StoredAPIKey
+
+class NotificationManager {
+    static let shared = NotificationManager() // Singleton for easy access
+
+    private init() {} // Private initializer for singleton
+
+    func scheduleExpirationNotifications(using context: NSManagedObjectContext, daysBefore: Int = 7) {
+        let center = UNUserNotificationCenter.current()
+
+        // Check notification settings to ensure we can schedule
+        center.getNotificationSettings { settings in
+            guard settings.authorizationStatus == .authorized else {
+                print("Notification authorization not granted. Cannot schedule notifications.")
+                // Optionally, guide user to settings if desired
+                return
+            }
+
+            let fetchRequest: NSFetchRequest<StoredAPIKey> = StoredAPIKey.fetchRequest()
+            // Filter for keys that have an expiration date set and are not yet expired
+            let now = Date()
+            fetchRequest.predicate = NSPredicate(format: "expirationDate != nil AND expirationDate >= %@", now as NSDate)
+
+            do {
+                let keysWithFutureExpiration = try context.fetch(fetchRequest)
+                
+                for apiKey in keysWithFutureExpiration {
+                    guard let expirationDate = apiKey.expirationDate, let keyId = apiKey.id?.uuidString, let keyName = apiKey.name else {
+                        continue // Skip if essential data is missing
+                    }
+
+                    let notificationIdentifier = keyId + "_expiration"
+                    
+                    // Remove any pending notification for this key first to avoid duplicates or outdated alerts
+                    center.removePendingNotificationRequests(withIdentifiers: [notificationIdentifier])
+
+                    // Calculate the trigger date: `daysBefore` the expirationDate, at 9 AM.
+                    guard let triggerDate = Calendar.current.date(byAdding: .day, value: -daysBefore, to: expirationDate) else {
+                        continue
+                    }
+                    
+                    // Only schedule if the trigger date is in the future
+                    if triggerDate <= now {
+                        // If the trigger date is past (e.g., key expires very soon or daysBefore is large),
+                        // you might want to handle it differently (e.g., notify immediately or adjust logic).
+                        // For now, we'll just skip scheduling if the reminder point is already passed.
+                        // Or, if it's already within the 'daysBefore' window but not past, it will be scheduled.
+                        // The initial fetch already filters for expirationDate >= now.
+                        // This check ensures the *notification trigger point* is in the future.
+                        
+                        // A more precise check: if the key expires today or in the future, but the trigger date is in the past,
+                        // it means we are past the ideal 'daysBefore' reminder point.
+                        // We could schedule it for 'now + a few seconds' if expirationDate is very soon.
+                        // For simplicity, if triggerDate is in the past, we just log and skip.
+                        if expirationDate > now && triggerDate <= now {
+                             print("Key '\(keyName)' (ID: \(keyId)) reminder point is in the past. Skipping notification scheduling or consider immediate alert.")
+                             continue
+                        } else if triggerDate <= now { // Double check to skip if trigger date is in the past
+                            continue
+                        }
+                    }
+
+                    var dateComponents = Calendar.current.dateComponents([.year, .month, .day], from: triggerDate)
+                    dateComponents.hour = 9 // At 9 AM
+                    dateComponents.minute = 0
+
+                    let content = UNMutableNotificationContent()
+                    content.title = "API Key Expiring Soon!"
+                    content.subtitle = "Key: \(keyName)"
+                    let dateFormatter = DateFormatter()
+                    dateFormatter.dateStyle = .medium
+                    dateFormatter.timeStyle = .none
+                    content.body = "Your API key '\(keyName)' is set to expire on \(dateFormatter.string(from: expirationDate))."
+                    content.sound = .default
+
+                    let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
+                    let request = UNNotificationRequest(identifier: notificationIdentifier, content: content, trigger: trigger)
+
+                    center.add(request) { error in
+                        if let error = error {
+                            print("Error scheduling notification for key \(keyName) (ID: \(keyId)): \(error.localizedDescription)")
+                        } else {
+                            print("Successfully scheduled notification for key \(keyName) (ID: \(keyId)) to trigger at \(dateComponents).")
+                        }
+                    }
+                }
+            } catch {
+                print("Failed to fetch API keys for notification scheduling: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/kees/kees/keesApp.swift
+++ b/kees/kees/keesApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import CoreData
+import UserNotifications // Import UserNotifications
 
 @main
 struct keesApp: App {
@@ -11,6 +12,10 @@ struct keesApp: App {
 
     // Initialize UIState for managing global UI states like sheet presentation
     @StateObject var uiState = UIState()
+
+    init() {
+        requestNotificationPermission()
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -29,6 +34,18 @@ struct keesApp: App {
                     uiState.showingAddKeySheet = true
                 }
                 .keyboardShortcut("n", modifiers: .command)
+            }
+        }
+    }
+
+    private func requestNotificationPermission() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+            if granted {
+                print("Notification permission granted.")
+            } else if let error = error {
+                print("Notification permission denied with error: \(error.localizedDescription)")
+            } else {
+                print("Notification permission denied (no error specified).")
             }
         }
     }


### PR DESCRIPTION
This commit delivers a significant portion of the "kees" macOS application functionality, including fixes for initial build errors related to Core Data and UI elements.

Key features and fixes included:
- Resolved Core Data model versioning and entity class (`StoredAPIKey`) code generation issues.
- Corrected macOS-incompatible ToolbarItem placements in `APIKeyEntryView`.
- Ensured SwiftUI Previews for Core Data dependent views (`APIKeyRowView`) are functional using an in-memory store.
- Implemented full CRUD (Create, Read, Update, Delete) operations for API keys:
    - Saving new/edited keys via `APIKeyEntryView`.
    - Fetching and displaying keys in `ContentView` using `APIKeyRowView`.
    - Deleting keys from the list.
- Added "Favorites" feature:
    - `isFavorite` attribute in `StoredAPIKey`.
    - UI to toggle favorite status in row and entry views.
    - Sidebar filter for "Favorites".
- Implemented a filter system in the sidebar for "All Keys", "Favorites", and "Recently Used" (currently sorts by creation date).
- Basic local notification system for API keys nearing their expiration date:
    - Requests user permission for notifications.
    - Schedules notifications based on the optional expiration date set for a key.

The application now has a robust set of features for managing API keys. The next step is to write comprehensive unit tests for the implemented logic.